### PR TITLE
Update 00_blackstone.txt

### DIFF
--- a/common/buildings/00_blackstone.txt
+++ b/common/buildings/00_blackstone.txt
@@ -162,6 +162,8 @@ tribal = {
 		ai_creation_factor = 0
 		tax_income = -2
 		liege_prestige = 0.2
+		convert_to_castle = ca_blackstone_mine_1
+		convert_to_city = ct_blackstone_mine_1
 	}
 }
 
@@ -187,6 +189,8 @@ nomad = {
 		ai_creation_factor = 0
 		tax_income = -2
 		liege_prestige = 0.2
+		convert_to_castle = ca_blackstone_mine_1
+		convert_to_city = ct_blackstone_mine_1
 	}
 }
 


### PR DESCRIPTION
An update to have tribal and nomadic Warpstone mines carry over when converted to Castle or City instead of needing to be rebuilt from scratch.