### PR TITLE
Cancer cure for immortal characters

### DIFF
--- a/events/rip_symptom_events.txt
+++ b/events/rip_symptom_events.txt
@@ -195,6 +195,12 @@ character_event = { #Cough can lead to pneumonia tuberculosis measles flu cancer
 								has_character_flag = developing_illness
 							}
 							has_character_flag = disease_not_serious
+							trait = immortal
+							has_artifact = elixir_of_eternal_youth
+                            trait = creature_elf
+                            trait = creature_orc
+                            trait = creature_goblin
+                            trait = creature_snotling
 						}
 					}
 					modifier = {
@@ -204,13 +210,6 @@ character_event = { #Cough can lead to pneumonia tuberculosis measles flu cancer
 					modifier = {
 						factor = 0.25
 						NOT = { age = 45 }
-					}
-					modifier = {
-						factor = 0.1
-						OR = {
-							trait = immortal
-							has_artifact = elixir_of_eternal_youth
-						}
 					}
 					modifier = {
 						factor = 2
@@ -245,20 +244,6 @@ character_event = { #Cough can lead to pneumonia tuberculosis measles flu cancer
 						OR = {
 							trait = creature_dwarf
 							trait = creature_chaos_dwarf
-						}
-					}
-
-					modifier = {
-						factor = 2
-						age = 500
-						trait = creature_elf
-					}
-					modifier = {
-						factor = 4
-						age = 1000
-						OR = {
-							trait = immortal
-							has_artifact = elixir_of_eternal_youth
 						}
 					}
 
@@ -1158,6 +1143,12 @@ character_event = { # diarrhea can lead to typhoid_fever typhus flu dysentery fo
 								has_character_flag = developing_illness
 							}
 							has_character_flag = disease_not_serious
+							trait = immortal
+							has_artifact = elixir_of_eternal_youth
+                            trait = creature_elf
+                            trait = creature_orc
+                            trait = creature_goblin
+                            trait = creature_snotling
 						}
 					}
 					modifier = {
@@ -1167,13 +1158,6 @@ character_event = { # diarrhea can lead to typhoid_fever typhus flu dysentery fo
 					modifier = {
 						factor = 0.25
 						NOT = { age = 45 }
-					}
-					modifier = {
-						factor = 0.1
-						OR = {
-							trait = immortal
-							has_artifact = elixir_of_eternal_youth
-						}
 					}
 					modifier = {
 						factor = 2
@@ -1209,20 +1193,6 @@ character_event = { # diarrhea can lead to typhoid_fever typhus flu dysentery fo
 						OR = {
 							trait = creature_dwarf
 							trait = creature_chaos_dwarf
-						}
-					}
-
-					modifier = {
-						factor = 2
-						age = 500
-						trait = creature_elf
-					}
-					modifier = {
-						factor = 2
-						age = 2000
-						OR = {
-							trait = immortal
-							has_artifact = elixir_of_eternal_youth
 						}
 					}
 
@@ -1406,6 +1376,12 @@ character_event = { #vomiting can lead to flu Food_Poisoning cancer
 								has_character_flag = developing_illness
 							}
 							has_character_flag = disease_not_serious
+							trait = immortal
+							has_artifact = elixir_of_eternal_youth
+                            trait = creature_elf
+                            trait = creature_orc
+                            trait = creature_goblin
+                            trait = creature_snotling
 						}
 					}
 					modifier = {
@@ -1415,13 +1391,6 @@ character_event = { #vomiting can lead to flu Food_Poisoning cancer
 					modifier = {
 						factor = 0.25
 						NOT = { age = 45 }
-					}
-					modifier = {
-						factor = 0.1
-						OR = {
-							trait = immortal
-							has_artifact = elixir_of_eternal_youth
-						}
 					}
 					modifier = {
 						factor = 2
@@ -1456,21 +1425,6 @@ character_event = { #vomiting can lead to flu Food_Poisoning cancer
 						OR = {
 							trait = creature_dwarf
 							trait = creature_chaos_dwarf
-						}
-					}
-
-					modifier = {
-						factor = 2
-						age = 500
-						trait = creature_elf
-					}
-
-					modifier = {
-						factor = 2
-						age = 2000
-						OR = {
-							trait = immortal
-							has_artifact = elixir_of_eternal_youth
 						}
 					}
 
@@ -1751,6 +1705,12 @@ character_event = { #headache can lead to syphilis typhus smallpox aztec_disease
 								has_character_flag = developing_illness
 							}
 							has_character_flag = disease_not_serious
+							trait = immortal
+							has_artifact = elixir_of_eternal_youth
+                            trait = creature_elf
+                            trait = creature_orc
+                            trait = creature_goblin
+                            trait = creature_snotling
 						}
 					}
 					modifier = {
@@ -1760,13 +1720,6 @@ character_event = { #headache can lead to syphilis typhus smallpox aztec_disease
 					modifier = {
 						factor = 0.25
 						NOT = { age = 45 }
-					}
-					modifier = {
-						factor = 0.1
-						OR = {
-							trait = immortal
-							has_artifact = elixir_of_eternal_youth
-						}
 					}
 					modifier = {
 						factor = 2
@@ -1786,21 +1739,6 @@ character_event = { #headache can lead to syphilis typhus smallpox aztec_disease
 						OR = {
 							trait = creature_dwarf
 							trait = creature_chaos_dwarf
-						}
-					}
-
-					modifier = {
-						factor = 2
-						age = 500
-						trait = creature_elf
-					}
-
-					modifier = {
-						factor = 2
-						age = 2000
-						OR = {
-							trait = immortal
-							has_artifact = elixir_of_eternal_youth
 						}
 					}
 
@@ -1975,6 +1913,12 @@ character_event = { #chest_pain can lead to pneumonia tuberculosis cancer
 								has_character_flag = developing_illness
 							}
 							has_character_flag = disease_not_serious
+							trait = immortal
+							has_artifact = elixir_of_eternal_youth
+                            trait = creature_elf
+                            trait = creature_orc
+                            trait = creature_goblin
+                            trait = creature_snotling
 						}
 					}
 					modifier = {
@@ -1984,13 +1928,6 @@ character_event = { #chest_pain can lead to pneumonia tuberculosis cancer
 					modifier = {
 						factor = 0.25
 						NOT = { age = 45 }
-					}
-					modifier = {
-						factor = 0.1
-						OR = {
-							trait = immortal
-							has_artifact = elixir_of_eternal_youth
-						}
 					}
 					modifier = {
 						factor = 2
@@ -2024,21 +1961,6 @@ character_event = { #chest_pain can lead to pneumonia tuberculosis cancer
 						OR = {
 							trait = creature_dwarf
 							trait = creature_chaos_dwarf
-						}
-					}
-
-					modifier = {
-						factor = 2
-						age = 500
-						trait = creature_elf
-					}
-
-					modifier = {
-						factor = 2
-						age = 2000
-						OR = {
-							trait = immortal
-							has_artifact = elixir_of_eternal_youth
 						}
 					}
 
@@ -2694,6 +2616,12 @@ character_event = { #abdominal_pain can lead to typhoid_fever typhus flu dysente
 								has_character_flag = developing_illness
 							}
 							has_character_flag = disease_not_serious
+							trait = immortal
+							has_artifact = elixir_of_eternal_youth
+                            trait = creature_elf
+                            trait = creature_orc
+                            trait = creature_goblin
+                            trait = creature_snotling
 						}
 					}
 					modifier = {
@@ -2703,13 +2631,6 @@ character_event = { #abdominal_pain can lead to typhoid_fever typhus flu dysente
 					modifier = {
 						factor = 0.25
 						NOT = { age = 45 }
-					}
-					modifier = {
-						factor = 0.1
-						OR = {
-							trait = immortal
-							has_artifact = elixir_of_eternal_youth
-						}
 					}
 					modifier = {
 						factor = 2
@@ -2743,21 +2664,6 @@ character_event = { #abdominal_pain can lead to typhoid_fever typhus flu dysente
 						OR = {
 							trait = creature_dwarf
 							trait = creature_chaos_dwarf
-						}
-					}
-
-					modifier = {
-						factor = 2
-						age = 500
-						trait = creature_elf
-					}
-
-					modifier = {
-						factor = 2
-						age = 2000
-						OR = {
-							trait = immortal
-							has_artifact = elixir_of_eternal_youth
 						}
 					}
 
@@ -3052,6 +2958,12 @@ character_event = { #fatigue can lead to tuberculosis typhus flu gout rabies can
 								has_character_flag = developing_illness
 							}
 							has_character_flag = disease_not_serious
+							trait = immortal
+							has_artifact = elixir_of_eternal_youth
+                            trait = creature_elf
+                            trait = creature_orc
+                            trait = creature_goblin
+                            trait = creature_snotling
 						}
 					}
 					modifier = {
@@ -3061,13 +2973,6 @@ character_event = { #fatigue can lead to tuberculosis typhus flu gout rabies can
 					modifier = {
 						factor = 0.25
 						NOT = { age = 45 }
-					}
-					modifier = {
-						factor = 0.1
-						OR = {
-							trait = immortal
-							has_artifact = elixir_of_eternal_youth
-						}
 					}
 					modifier = {
 						factor = 2
@@ -3106,21 +3011,6 @@ character_event = { #fatigue can lead to tuberculosis typhus flu gout rabies can
 
 					modifier = {
 						factor = 2
-						age = 500
-						trait = creature_elf
-					}
-
-					modifier = {
-						factor = 2
-						age = 2000
-						OR = {
-							trait = immortal
-							has_artifact = elixir_of_eternal_youth
-						}
-					}
-
-					modifier = {
-						factor = 2
 						age = 100
 						is_member_of_bretonnia_trigger = yes
 					}
@@ -3134,17 +3024,6 @@ character_event = { #fatigue can lead to tuberculosis typhus flu gout rabies can
 						}
 					}
 
-					modifier = {
-						factor = 2
-						age = 500
-						trait = creature_elf
-					}
-
-					modifier = {
-						factor = 2
-						age = 2000
-						trait = immortal
-					}
 					if = {
 						limit = {
 							NOR = {
@@ -3423,6 +3302,12 @@ character_event = { #malaise can lead to typhoid_fever bubonic_plague smallpox/a
 								has_character_flag = developing_illness
 							}
 							has_character_flag = disease_not_serious
+							trait = immortal
+							has_artifact = elixir_of_eternal_youth
+                            trait = creature_elf
+                            trait = creature_orc
+                            trait = creature_goblin
+                            trait = creature_snotling
 						}
 					}
 					modifier = {
@@ -3432,13 +3317,6 @@ character_event = { #malaise can lead to typhoid_fever bubonic_plague smallpox/a
 					modifier = {
 						factor = 0.25
 						NOT = { age = 45 }
-					}
-					modifier = {
-						factor = 0.1
-						OR = {
-							trait = immortal
-							has_artifact = elixir_of_eternal_youth
-						}
 					}
 					modifier = {
 						factor = 2
@@ -3473,21 +3351,6 @@ character_event = { #malaise can lead to typhoid_fever bubonic_plague smallpox/a
 						OR = {
 							trait = creature_dwarf
 							trait = creature_chaos_dwarf
-						}
-					}
-
-					modifier = {
-						factor = 2
-						age = 500
-						trait = creature_elf
-					}
-
-					modifier = {
-						factor = 2
-						age = 2000
-						OR = {
-							trait = immortal
-							has_artifact = elixir_of_eternal_youth
 						}
 					}
 


### PR DESCRIPTION
After playing a few decades into a game I noticed that all the canon immortal characters had cancer, so I made some changes to prevent characters that should be able to get cancer from getting it. This is mostly for elves, although I included the various greenskins as well--they're theoretically immortal, although in practice they normally die in combat before they get old enough for it to matter.