### PR TITLE
Update DR_chaos_dwarfs_events.txt

### DIFF
--- a/events/DR_chaos_dwarfs_events.txt
+++ b/events/DR_chaos_dwarfs_events.txt
@@ -4267,6 +4267,7 @@ character_event = {
 					if = {
 						limit = {
 							capital_holding = { has_building = ca_chaos_dwarf_factory_3 }
+							NOT = capital_holding = { has_building = ca_chaos_dwarf_factory_4 }
 						}
 						capital_holding = {
 								remove_building = ca_chaos_dwarf_factory_3
@@ -4277,6 +4278,8 @@ character_event = {
 					if = {
 						limit = {
 							capital_holding = { has_building = ca_chaos_dwarf_factory_2 }
+							NOT = capital_holding = { has_building = ca_chaos_dwarf_factory_3 }
+							NOT = capital_holding = { has_building = ca_chaos_dwarf_factory_4 }
 						}
 						capital_holding = {
 								remove_building = ca_chaos_dwarf_factory_2
@@ -4311,6 +4314,7 @@ character_event = {
 					if = {
 						limit = {
 							capital_holding = { has_building = ct_chaos_dwarf_factory_3 }
+							NOT = capital_holding = { has_building = ct_chaos_dwarf_factory_4 }
 						}
 						capital_holding = {
 								remove_building = ct_chaos_dwarf_factory_3
@@ -4321,6 +4325,8 @@ character_event = {
 					if = {
 						limit = {
 							capital_holding = { has_building = ct_chaos_dwarf_factory_2 }
+							NOT = capital_holding = { has_building = ct_chaos_dwarf_factory_3 }
+							NOT = capital_holding = { has_building = ct_chaos_dwarf_factory_4 }
 						}
 						capital_holding = {
 								remove_building = ct_chaos_dwarf_factory_2
@@ -4355,6 +4361,7 @@ character_event = {
 					if = {
 						limit = {
 							family_palace = { has_building = tp_chaos_dwarf_factory_3 }
+							NOT = capital_holding = { has_building = tp_chaos_dwarf_factory_4 }
 						}
 						family_palace = {
 								remove_building = tp_chaos_dwarf_factory_3
@@ -4365,6 +4372,8 @@ character_event = {
 					if = {
 						limit = {
 							family_palace = { has_building = tp_chaos_dwarf_factory_2 }
+							NOT = capital_holding = { has_building = tp_chaos_dwarf_factory_3 }
+							NOT = capital_holding = { has_building = tp_chaos_dwarf_factory_4 }
 						}
 						family_palace = {
 								remove_building = tp_chaos_dwarf_factory_2
@@ -4404,6 +4413,7 @@ character_event = {
 					if = {
 						limit = {
 							capital_holding = { has_building = tp_chaos_dwarf_factory_3 }
+							NOT = capital_holding = { has_building = tp_chaos_dwarf_factory_4 }
 						}
 						capital_holding = {
 								remove_building = tp_chaos_dwarf_factory_3
@@ -4414,6 +4424,8 @@ character_event = {
 					if = {
 						limit = {
 							capital_holding = { has_building = tp_chaos_dwarf_factory_2 }
+							NOT = capital_holding = { has_building = tp_chaos_dwarf_factory_3 }
+							NOT = capital_holding = { has_building = tp_chaos_dwarf_factory_4 }
 						}
 						capital_holding = {
 								remove_building = tp_chaos_dwarf_factory_2
@@ -4498,6 +4510,7 @@ character_event = {
 					if = {
 						limit = {
 							capital_holding = { has_building = ca_chaos_dwarf_slave_levy_3 }
+							NOT = capital_holding = { has_building = ca_chaos_dwarf_slave_levy_4 }
 						}
 						capital_holding = {
 								remove_building = ca_chaos_dwarf_slave_levy_3
@@ -4508,6 +4521,8 @@ character_event = {
 					if = {
 						limit = {
 							capital_holding = { has_building = ca_chaos_dwarf_slave_levy_2 }
+							NOT = capital_holding = { has_building = ca_chaos_dwarf_slave_levy_3 }
+							NOT = capital_holding = { has_building = ca_chaos_dwarf_slave_levy_4 }
 						}
 						capital_holding = {
 								remove_building = ca_chaos_dwarf_slave_levy_2
@@ -4542,6 +4557,7 @@ character_event = {
 					if = {
 						limit = {
 							capital_holding = { has_building = ct_chaos_dwarf_slave_levy_3 }
+							NOT = capital_holding = { has_building = ct_chaos_dwarf_slave_levy_4 }
 						}
 						capital_holding = {
 								remove_building = ct_chaos_dwarf_slave_levy_3
@@ -4552,6 +4568,8 @@ character_event = {
 					if = {
 						limit = {
 							capital_holding = { has_building = ct_chaos_dwarf_slave_levy_2 }
+							NOT = capital_holding = { has_building = ct_chaos_dwarf_slave_levy_3 }
+							NOT = capital_holding = { has_building = ct_chaos_dwarf_slave_levy_4 }
 						}
 						capital_holding = {
 								remove_building = ct_chaos_dwarf_slave_levy_2
@@ -4586,6 +4604,7 @@ character_event = {
 					if = {
 						limit = {
 							family_palace = { has_building = tp_chaos_dwarf_slave_levy_3 }
+							NOT = capital_holding = { has_building = tp_chaos_dwarf_slave_levy_4 }
 						}
 						family_palace = {
 								remove_building = tp_chaos_dwarf_slave_levy_3
@@ -4596,6 +4615,8 @@ character_event = {
 					if = {
 						limit = {
 							family_palace = { has_building = tp_chaos_dwarf_slave_levy_2 }
+							NOT = capital_holding = { has_building = tp_chaos_dwarf_slave_levy_3 }
+							NOT = capital_holding = { has_building = tp_chaos_dwarf_slave_levy_4 }
 						}
 						family_palace = {
 								remove_building = tp_chaos_dwarf_slave_levy_2
@@ -4635,6 +4656,7 @@ character_event = {
 					if = {
 						limit = {
 							capital_holding = { has_building = tp_chaos_dwarf_slave_levy_3 }
+							NOT = capital_holding = { has_building = tp_chaos_dwarf_slave_levy_4 }
 						}
 						capital_holding = {
 								remove_building = tp_chaos_dwarf_slave_levy_3
@@ -4645,6 +4667,8 @@ character_event = {
 					if = {
 						limit = {
 							capital_holding = { has_building = tp_chaos_dwarf_slave_levy_2 }
+							NOT = capital_holding = { has_building = tp_chaos_dwarf_slave_levy_3 }
+							NOT = capital_holding = { has_building = tp_chaos_dwarf_slave_levy_4 }
 						}
 						capital_holding = {
 								remove_building = tp_chaos_dwarf_slave_levy_2


### PR DESCRIPTION
Currently if the decay event fires for the Dawi Zhar slave buildings no matter what level they are at, they get cut down to the tier 1 building. looking at the code I interpreted that it was not intended to do that, and instead it was intended to only go down 1 level upon decaying. I've added additional checks since CK2 buildings are cumulative and I'm fairly certain that having tier 4 of a building means also having tier 2 and 3 of said building, which then hits the current triggers for destroying tier 4, 3, and 2 of the building. With these checks it shouldn't destroy everything down to tier 1 of the buildings if you have a higher tier building.